### PR TITLE
set schema type on reference if not defined

### DIFF
--- a/jjve.js
+++ b/jjve.js
@@ -212,6 +212,8 @@
             o.schema = o.env.resolveRef(null, o.schema);
             if (o.schema) o.schema = o.schema[0];
           }
+
+          if (!o.schema.type) o.schema.type = 'object';
         }
 
         if (o.schema && o.schema.type) {

--- a/test/errors.js
+++ b/test/errors.js
@@ -465,6 +465,38 @@ describe('jjve', function() {
       ]);
     });
 
+    it('should handle schema ref without a type defined', function() {
+      var data = { one: { two: '' } };
+
+      var ref = {
+        id: 'one',
+        properties: {
+          two: {
+            type: 'string',
+            minLength: 1,
+          }
+        }
+      };
+
+      var schema = {
+        type: 'object',
+        properties: {
+          one: { $ref: 'one' }
+        },
+      };
+
+      this.env.addSchema(ref);
+
+      this.run(schema, data).should.eql([
+        {
+          code: 'VALIDATION_MIN_LENGTH',
+          message: 'String is too short (0 chars), minimum 1',
+          data: '',
+          path: '$.one.two'
+        }
+      ]);
+    });
+
     it('should handle type property given as array where leaf schema is needed',
        function() {
       var data = { test: 'xyz' };


### PR DESCRIPTION
If the referenced schema does not have a type set referenced property is not pulled out correctly.
 1) The `s` variable is not set to the request property schema
 2) The `schema` value passed to `make` is empty, resulting in bad error messages: `String is too short (0 chars), minimum undefined`