### PR TITLE
Fix linting errors

### DIFF
--- a/jjve.js
+++ b/jjve.js
@@ -1,6 +1,23 @@
 (function() {
   'use strict';
 
+  function isArray(obj) {
+    if (typeof Array.isArray === 'function') {
+      return Array.isArray(obj);
+    }
+    return Object.prototype.toString.call(obj) === '[object Array]';
+  }
+
+  function allowsType(schema, type) {
+    if (typeof schema.type === 'string') {
+      return schema.type === type;
+    }
+    if (isArray(schema.type)) {
+      return schema.type.indexOf(type) !== -1;
+    }
+    return false;
+  }
+
   function make(o) {
     var errors = [];
 
@@ -276,23 +293,6 @@
     }
 
     return errors;
-  }
-
-  function allowsType(schema, type) {
-    if (typeof schema.type === 'string') {
-      return schema.type === type;
-    }
-    if (isArray(schema.type)) {
-      return schema.type.indexOf(type) !== -1;
-    }
-    return false;
-  }
-
-  function isArray(obj) {
-    if (typeof Array.isArray === 'function') {
-      return Array.isArray(obj);
-    }
-    return Object.prototype.toString.call(obj) === '[object Array]';
   }
 
   function formatPath(options) {


### PR DESCRIPTION
Move functions to the top of the file to get rid of W117 (http://jslinterrors.com/a-was-used-before-it-was-defined) linting errors.