### PR TITLE
Add `undefined` check to `o.schema.$ref`

### DIFF
--- a/jjve.js
+++ b/jjve.js
@@ -4,6 +4,23 @@
   function make(o) {
     var errors = [];
 
+    function isArray(obj) {
+      if (typeof Array.isArray === 'function') {
+        return Array.isArray(obj);
+      }
+      return Object.prototype.toString.call(obj) === '[object Array]';
+    }
+
+    function allowsType(schema, type) {
+      if (typeof schema.type === 'string') {
+        return schema.type === type;
+      }
+      if (isArray(schema.type)) {
+        return schema.type.indexOf(type) !== -1;
+      }
+      return false;
+    }
+
     var keys = Object.keys(o.validation);
 
     // when we're on a leaf node we need to handle the validation errors,
@@ -276,23 +293,6 @@
     }
 
     return errors;
-  }
-
-  function allowsType(schema, type) {
-    if (typeof schema.type === 'string') {
-      return schema.type === type;
-    }
-    if (isArray(schema.type)) {
-      return schema.type.indexOf(type) !== -1;
-    }
-    return false;
-  }
-
-  function isArray(obj) {
-    if (typeof Array.isArray === 'function') {
-      return Array.isArray(obj);
-    }
-    return Object.prototype.toString.call(obj) === '[object Array]';
   }
 
   function formatPath(options) {

--- a/jjve.js
+++ b/jjve.js
@@ -201,7 +201,7 @@
       keys.forEach(function(key) {
         var s;
 
-        if (o.schema.$ref) {
+        if (o.schema && o.schema.$ref) {
           if (o.schema.$ref.match(/#\/definitions\//)) {
             o.schema = o.definitions[o.schema.$ref.slice(14)];
           } else {


### PR DESCRIPTION
# Add `undefined` check to `o.schema.$ref`

Great work on this library. We've been using this extensively in our model layer. So to begin with, thank you! :smile:

## Context

We recently came across a problem with validation. The error log being thrown from `jjve` was `TypeError: Cannot read property '$ref' of undefined`

Adding an `undefined` check to [L204](https://github.com/silas/jjve/blob/master/jjve.js#L204) fixed this issue, and all validations were perfectly parsed.

Raising this PR to add that `undefined` check 😄 